### PR TITLE
Update SSH private key secret for GitHub Actions deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.1
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.TRADE_AUTO_DEPLOY }}
 
       - name: Deploy to VPS
         env:


### PR DESCRIPTION
Replace the SSH private key secret used in the GitHub Actions workflow to ensure proper deployment to the VPS.